### PR TITLE
Update beamerinnerthemeRub.sty

### DIFF
--- a/tex/latex/rub-beamer/beamerinnerthemeRub.sty
+++ b/tex/latex/rub-beamer/beamerinnerthemeRub.sty
@@ -21,10 +21,9 @@
 \ExecuteOptionsBeamer{alternativetitlepage=normal}
 \ProcessOptionsBeamer
 
-%% Einige Bilder definieren:
-% Logo und Wortmarke für die Titelseite
+%% Bild definieren:
+% Logo für die Titelseite
 \pgfdeclareimage[width=1.8cm]{logoTitle}{logo}
-\pgfdeclareimage[width=3cm]{wortmarkeTitle}{wortmarke}
 
 % Bilder für das Literaturverzeichnis
 \pgfdeclareimage[width=14pt,height=12pt]{beamericonbook}{beamericonbook}


### PR DESCRIPTION
Wortmarke was replaced with \textbf{RUHR-UNIVERSIT\"{A}T}~BOCHUM
