### PR TITLE
\insertshortdate im footer.

### DIFF
--- a/tex/latex/rub-beamer/beamerouterthemeRub.sty
+++ b/tex/latex/rub-beamer/beamerouterthemeRub.sty
@@ -86,7 +86,7 @@
         \framelatex{
             \begin{beamercolorbox}[leftskip=.3cm,wd=\paperwidth,ht=0.3\beamer@headheight,sep=0.1cm]{section in head/foot}    
                 \usebeamerfont{section in head/foot}%
-                \insertshortauthor~$|$~\insertshorttitle~$|$~\insertdate
+                \insertshortauthor~$|$~\insertshorttitle~$|$~\insertshortdate
                 \hfill
                 \insertframenumber%$|$\inserttotalframenumber
 		\hspace*{10pt}


### PR DESCRIPTION
- Wenn kein kurzes Datum angeboten wird (\date{\today}), wird das normale Datum auf der Titelseite und im Fuß der einzelnen Folien genutzt.
- Wenn zusätzlich ein kurzes Datum angeboten wird (\date[\today]]{Konferenz am \today]}), kommt das lange Datum auf die Titelseite und das kurze Datum in den Fuß der Folien.
  Dadurch ist es möglich wie gehabt das Datum mit (\date{\today}) zu setzen. Zusätzlich ist es dadurch möglich, in das lange Datum z. B. den Konferenztitel oder -ort zu übernehmen (\date[\today]{Konferenz am \today}). Closes #5
