### PR TITLE
RUB-Theme mit LuaLaTeX.

### DIFF
--- a/tex/latex/rub-beamer/beamerfontthemeRub.sty
+++ b/tex/latex/rub-beamer/beamerfontthemeRub.sty
@@ -10,7 +10,38 @@
 \ProvidesPackage{beamerfontthemeRub}[27/09/12 19:41:02]
 
 % Schriften aus dem Corporate Design laden
-\RequirePackage{rubfonts2009}
+
+% ToDo: Vielleicht global verfuegbar machen?
+% ifxetexorluatex seen at 
+% http://tex.stackexchange.com/a/47579
+\RequirePackage{ifxetex,ifluatex}
+
+\newif\ifxetexorluatex
+\ifxetex
+  \xetexorluatextrue
+\else
+  \ifluatex
+    \xetexorluatextrue
+  \else
+    \xetexorluatexfalse
+  \fi
+\fi
+
+\ifxetexorluatex
+  \RequirePackage{fontspec}
+  \setmainfont{RubFlama}
+  \setsansfont{RubFlama}
+  \setromanfont{RUB Scala TZ}
+  \ifxetex
+    \RequirePackage[EU1]{fontenc}
+  \else
+    \RequirePackage[EU2]{fontenc}
+  \fi
+\else
+  \RequirePackage{rubfonts2009}
+  \RequirePackage[T1]{fontenc}    % 
+  \RequirePackage[utf8]{inputenc} % ToDo: Möglicherweise unerwünscht.
+\fi
 
 \mode<presentation>
 


### PR DESCRIPTION
Durch die Änderungen wird es ermöglicht, eine Beamer-Präsentation mit LuaLaTeX zu kompilieren. Dadurch ist es möglich, in Präsentationen z. B. Buchstabenkombinationen wie „fi“ zu suchen. Die durch das Paket rubfonts2009 eingebundenen Schriftarten ermöglichen dies nicht. Damit die Schriftarten eingebunden sind, müssen die RUB-TTF-Schriften in den Fonts Ordner des Betriebssystems geschoben werden (zur Überprüfung, die Schriftarten müssen in einem Officeprogramm verfügbar sein).

Mit LuaLaTeX kann ein PDF erzeugt werden, welches identisch ist zu einem mit PDFLaTeX erzeugten. Nach den Änderungen kann auch mit XeLaTeX ein PDF erstellt werden, dieses ist jedoch aufgrund eines mir derzeit unbekannten Problems (vermutlich mit Abständen oder Tikz) unbrauchbar.
