### PR TITLE
Removed unwanted footer from titlepage options bild, alternativ & bildempty

### DIFF
--- a/tex/latex/rub-beamer/beamerinnerthemeRub.sty
+++ b/tex/latex/rub-beamer/beamerinnerthemeRub.sty
@@ -124,6 +124,7 @@
 %% Alternativ
 \defbeamertemplate*{title page alternativ}{Rub}
 {   % Beginn der Definition: Alternativ
+\thispagestyle{empty}
 \begin{tikzpicture}[remember picture,overlay]
 % Erste Node: Setzt ganz oben links an, von dem Punkt aus kann dann in der zweiten tikzpicture Umgebung ausgegangen werden
 \node[anchor=north west, inner sep=0pt]  at (current page.north west) {
@@ -181,6 +182,7 @@
 %% Alternativ mit großem Bild
 \defbeamertemplate*{title page bild}{Rub}
 {  % Beginn der Definition: Bild
+\thispagestyle{empty}
 \begin{tikzpicture}[remember picture,overlay]
 % Erste Node: Setzt ganz oben links an, von dem Punkt aus kann dann in der zweiten tikzpicture Umgebung ausgegangen werden
 \node[anchor=north west, inner sep=0pt]  at (current page.north west) {
@@ -239,6 +241,7 @@
 %% Alternativ mit großem Bild/empty (aufgeräumter Modus)
 \defbeamertemplate*{title page bildempty}{Rub}
 {  % Beginn der Definition: Bild
+\thispagestyle{empty}
 \begin{tikzpicture}[remember picture,overlay]
 % Erste Node: Setzt ganz oben links an, von dem Punkt aus kann dann in der zweiten tikzpicture Umgebung ausgegangen werden
 \node[anchor=north west, inner sep=0pt]  at (current page.north west) {


### PR DESCRIPTION
The titlepage options bild, alternativ and bildempty show a footer like in the following exemplary image:

![before](https://user-images.githubusercontent.com/39367795/71897261-5b7ba600-3156-11ea-8799-124bc8e19cb9.png)

This violates the official corporate design and differs from the result shown in the images from the README (e.g. https://camo.githubusercontent.com/17706130d7f14616e15df80593d688fd9cefcaa3/687474703a2f2f7777772e737461742e7275622e64652f6c617465782f62696c642e706e67).

The fix creates the correct result:

![after](https://user-images.githubusercontent.com/39367795/71897322-8960ea80-3156-11ea-8d7a-1dfe6fbb2871.png)
